### PR TITLE
fix: rename timestamp to created_at in InteractionModel

### DIFF
--- a/backend/app/models/interaction.py
+++ b/backend/app/models/interaction.py
@@ -31,10 +31,8 @@ class InteractionLogCreate(SQLModel):
 
 
 class InteractionModel(SQLModel):
-    """Response schema for an interaction."""
-
     id: int
     learner_id: int
     item_id: int
     kind: str
-    timestamp: datetime
+    created_at: datetime


### PR DESCRIPTION
Replaced 'timestamp' with 'created_at' in InteractionModel.

<!-- Provide a general summary of your changes in the Title above -->

## Summary

<!-- What does this PR do?

Replace <issue-number> with the number of the corresponding task issue.

Add more details if necessary.
-->

- Closes #<issue-number>

---

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I made this PR to the `main` branch **of my fork (NOT the course instructors' repo)**.
- [ ] I see `base: main` <- `compare: <branch-name>` above the PR title.
- [ ] I edited the line `- Closes #<issue-number>`.
- [ ] I wrote clear commit messages.
- [ ] I reviewed my own diff before requesting review.
- [ ] I understand the changes I’m submitting.
